### PR TITLE
DPT-604 Check output location is empty before copy

### DIFF
--- a/basestar-spark/src/main/java/io/basestar/spark/util/HadoopFSUtils.java
+++ b/basestar-spark/src/main/java/io/basestar/spark/util/HadoopFSUtils.java
@@ -1,0 +1,30 @@
+package io.basestar.spark.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class HadoopFSUtils {
+
+    /**
+     * Checks whether the given location does not exist or is an empty directory.
+     */
+    public static boolean isEmpty(final Configuration configuration, final URI location) {
+        try {
+            final Path path = new Path(location);
+            final FileSystem fs = path.getFileSystem(configuration);
+            if (!fs.exists(path)) {
+                return true;
+            }
+
+            // will return self if it is a file, or contents if it is a directory
+            return !fs.listStatusIterator(path).hasNext();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed check if empty location: " + location, e);
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.20.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 <!--    <reporting>-->


### PR DESCRIPTION
- Check output location is empty before copy
- Copy table using Overwrite to avoid write failures on empty directories
- Test coverage