### PR TITLE
DPT-913 Add create-or-update functionality to GQL

### DIFF
--- a/basestar-database-server/src/main/java/io/basestar/database/action/UpdateAction.java
+++ b/basestar-database-server/src/main/java/io/basestar/database/action/UpdateAction.java
@@ -79,13 +79,14 @@ public class UpdateAction implements Action {
 
         final Map<String, Object> data = new HashMap<>();
         final UpdateOptions.Mode mode = Nullsafe.orDefault(options.getMode(), UpdateOptions.Mode.REPLACE);
+        final boolean create = Nullsafe.orDefault(options.getCreate(), Boolean.FALSE);
 
         final long afterVersion;
         final Instant created;
         final Instant updated = ISO8601.now();
 
         if (before == null) {
-            if (mode == UpdateOptions.Mode.CREATE) {
+            if (create) {
                 afterVersion = 1L;
                 created = updated;
             } else {

--- a/basestar-database-server/src/test/java/io/basestar/database/api/TestDatabaseAPI.java
+++ b/basestar-database-server/src/test/java/io/basestar/database/api/TestDatabaseAPI.java
@@ -160,7 +160,8 @@ class TestDatabaseAPI {
         final DatabaseAPI api = new DatabaseAPI(db);
         api.handle(request(APIRequest.Method.PUT, "Test1/1", ImmutableMap.of(), new Properties("a", "b"))).join();
         Mockito.verify(db).update(Caller.ANON, UpdateOptions.builder()
-                .setSchema(Name.of("Test1")).setId("1").setData(ImmutableMap.of("f1", "a", "f2", "b")).setMode(UpdateOptions.Mode.CREATE).build());
+                .setSchema(Name.of("Test1")).setId("1").setData(ImmutableMap.of("f1", "a", "f2", "b"))
+                .setMode(UpdateOptions.Mode.REPLACE).setCreate(true).build());
     }
 
     @Test
@@ -170,7 +171,8 @@ class TestDatabaseAPI {
         final DatabaseAPI api = new DatabaseAPI(db);
         api.handle(request(APIRequest.Method.PATCH, "Test1/1", ImmutableMap.of(), new Properties("a", "b"))).join();
         Mockito.verify(db).update(Caller.ANON, UpdateOptions.builder()
-                .setSchema(Name.of("Test1")).setId("1").setData(ImmutableMap.of("f1", "a", "f2", "b")).setMode(UpdateOptions.Mode.MERGE_DEEP).build());
+                .setSchema(Name.of("Test1")).setId("1").setData(ImmutableMap.of("f1", "a", "f2", "b"))
+                .setMode(UpdateOptions.Mode.MERGE_DEEP).setCreate(false).build());
     }
 
     @Test

--- a/basestar-database/src/main/java/io/basestar/database/options/UpdateOptions.java
+++ b/basestar-database/src/main/java/io/basestar/database/options/UpdateOptions.java
@@ -43,7 +43,6 @@ public class UpdateOptions implements ActionOptions {
 
     public enum Mode {
 
-        CREATE,
         REPLACE,
         MERGE,
         MERGE_DEEP
@@ -64,6 +63,8 @@ public class UpdateOptions implements ActionOptions {
     private final Set<Name> projection;
 
     private final Long version;
+
+    private final Boolean create;
 
     private final Mode mode;
 

--- a/basestar-graphql/src/main/java/io/basestar/graphql/GraphQLAdaptor.java
+++ b/basestar-graphql/src/main/java/io/basestar/graphql/GraphQLAdaptor.java
@@ -300,10 +300,11 @@ public class GraphQLAdaptor {
             final Map<String, Object> data = requestTransform.fromRequest(schema, env.getArgument(strategy.dataArgumentName()));
             final Consistency consistency = consistency(env);
             final Map<String, Expression> expressions = parseExpressions(env.getArgument(strategy.expressionsArgumentName()));
+            final Boolean create = env.getArgument(strategy.createArgumentName());
 
             final UpdateOptions options = UpdateOptions.builder()
                     .setSchema(schema.getQualifiedName()).setId(id)
-                    .setMode(mode).setConsistency(consistency)
+                    .setMode(mode).setCreate(create).setConsistency(consistency)
                     .setData(data).setVersion(version)
                     .setExpressions(expressions)
                     .setExpand(expand)

--- a/basestar-graphql/src/main/java/io/basestar/graphql/GraphQLStrategy.java
+++ b/basestar-graphql/src/main/java/io/basestar/graphql/GraphQLStrategy.java
@@ -98,6 +98,8 @@ public interface GraphQLStrategy {
 
     String dataArgumentName();
 
+    String createArgumentName();
+
     String expressionsArgumentName();
 
     String consistencyArgumentName();
@@ -348,6 +350,12 @@ public interface GraphQLStrategy {
         public String dataArgumentName() {
 
             return "data";
+        }
+
+        @Override
+        public String createArgumentName() {
+
+            return "create";
         }
 
         @Override

--- a/basestar-graphql/src/main/java/io/basestar/graphql/schema/SchemaAdaptor.java
+++ b/basestar-graphql/src/main/java/io/basestar/graphql/schema/SchemaAdaptor.java
@@ -280,6 +280,8 @@ public class SchemaAdaptor {
         builder.inputValueDefinition(InputValueDefinition.newInputValueDefinition()
                 .name(strategy.versionArgumentName()).type(new TypeName(GraphQLUtils.INT_TYPE)).build());
         builder.inputValueDefinition(InputValueDefinition.newInputValueDefinition()
+                .name(strategy.createArgumentName()).type(new TypeName(GraphQLUtils.BOOLEAN_TYPE)).build());
+        builder.inputValueDefinition(InputValueDefinition.newInputValueDefinition()
                 .name(strategy.dataArgumentName()).type(new TypeName(typeName)).build());
         builder.inputValueDefinition(InputValueDefinition.newInputValueDefinition()
                 .name(strategy.consistencyArgumentName()).type(new TypeName(strategy.consistencyTypeName())).build());

--- a/basestar-graphql/src/test/java/io/basestar/graphql/GraphQLTest.java
+++ b/basestar-graphql/src/test/java/io/basestar/graphql/GraphQLTest.java
@@ -270,6 +270,35 @@ class GraphQLTest {
     }
 
     @Test
+    void testUpdateCreate() throws Exception {
+
+        final Namespace namespace = namespace();
+        final GraphQL graphQL = graphQL(namespace);
+
+        final ExecutionResult update = graphQL.execute(ExecutionInput.newExecutionInput()
+                .query("mutation {\n" +
+                        "  updateTest1(id:\"x\", data:{x:\"x\"}) {\n" +
+                        "    id\n" +
+                        "  }\n" +
+                        "}")
+                .context(GraphQLContext.newContext().of("caller", Caller.SUPER).build())
+                .build());
+        assertEquals(1, update.getErrors().size());
+
+        final ExecutionResult updateCreate = graphQL.execute(ExecutionInput.newExecutionInput()
+                .query("mutation {\n" +
+                        "  updateTest1(id:\"x\", data:{x:\"x\"}, create:true) {\n" +
+                        "    id\n" +
+                        "  }\n" +
+                        "}")
+                .context(GraphQLContext.newContext().of("caller", Caller.SUPER).build())
+                .build());
+
+        assertEquals(0, updateCreate.getErrors().size());
+        assertEquals(1, updateCreate.<Map<String, Map<String, Object>>>getData().get("updateTest1").size());
+    }
+
+    @Test
     void testMultiMutate() throws Exception {
 
         final Namespace namespace = namespace();


### PR DESCRIPTION
Previously, the update method in the REST API supported a mode parameter which could be set to CREATE/REPLACE/MERGE/MERGE_DEEP, however this doesn't give enough flexibility to say for e.g. create if not exists or merge. Rather than adding CREATE_MERGE, CREATE_MERGE_DEEP and having to document CREATE as being CREATE_REPLACE or breaking the API anyway, I have opted to split create-if-not-exists behaviour to it's own option, and surface this in GQL (where the other update modes are driven by the name of the methods already).

This changes the interface of the PUT/POST/PATCH REST API methods, however these are not generally used except in the CLI, and the CLI uses the default UpdateMode of REPLACE so it is not going to change anything we are doing.