### PR TITLE
DPT-944 Faster metadata queries

### DIFF
--- a/basestar-schema/src/test/java/io/basestar/schema/TestSchema.java
+++ b/basestar-schema/src/test/java/io/basestar/schema/TestSchema.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSchema {
 
@@ -46,5 +47,15 @@ public class TestSchema {
         final Query query = schema.requireQuery("byPet", true);
         assertEquals(Expression.parseAndBind(Context.init(), "pet.id == petId"), query.getExpression());
         assertEquals(1, query.getArguments().size());
+    }
+
+    @Test
+    void testUnknownSchemaType() throws Exception {
+
+        // This is unusual behaviour - JsonTypeInfo/JsonSubTypes does not have a concept of a default implementation only when unspecified
+        // Test added as documentation of this behaviour for now
+        final Namespace namespace = Namespace.load(TestInterfaceSchema.class.getResource("unknown.yml"));
+        final Schema<?> schema = namespace.requireSchema("Unknown");
+        assertTrue(schema instanceof ObjectSchema);
     }
 }

--- a/basestar-schema/src/test/resources/io/basestar/schema/unknown.yml
+++ b/basestar-schema/src/test/resources/io/basestar/schema/unknown.yml
@@ -1,0 +1,2 @@
+Unknown:
+  type: unknown

--- a/basestar-storage-sql/src/main/java/io/basestar/storage/sql/dialect/JSONDialect.java
+++ b/basestar-storage-sql/src/main/java/io/basestar/storage/sql/dialect/JSONDialect.java
@@ -31,7 +31,7 @@ import java.util.*;
 @Slf4j
 public abstract class JSONDialect implements SQLDialect {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper().registerModule(BasestarModule.INSTANCE);
+    protected static final ObjectMapper objectMapper = new ObjectMapper().registerModule(BasestarModule.INSTANCE);
 
     protected abstract boolean isJsonEscaped();
 

--- a/basestar-storage-sql/src/main/java/io/basestar/storage/sql/strategy/SQLStrategy.java
+++ b/basestar-storage-sql/src/main/java/io/basestar/storage/sql/strategy/SQLStrategy.java
@@ -23,6 +23,8 @@ package io.basestar.storage.sql.strategy;
 import io.basestar.schema.Schema;
 import io.basestar.storage.sql.util.DDLStep;
 import org.jooq.DSLContext;
+import org.jooq.Name;
+import org.jooq.Table;
 import org.jooq.conf.StatementType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,4 +55,9 @@ public interface SQLStrategy {
     StatementType statementType();
 
     boolean useMetadata();
+
+    default Table<?> describeTable(final DSLContext context, final Name name) {
+
+        return dialect().describeTable(context, name);
+    }
 }

--- a/basestar-storage-sql/src/test/java/io/basestar/storage/sql/TestSnowflakeStorage.java
+++ b/basestar-storage-sql/src/test/java/io/basestar/storage/sql/TestSnowflakeStorage.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import io.basestar.expression.Expression;
 import io.basestar.schema.*;
 import io.basestar.schema.use.UseString;
+import io.basestar.schema.util.Casing;
 import io.basestar.storage.Storage;
 import io.basestar.storage.sql.dialect.SnowflakeDialect;
 import io.basestar.storage.sql.strategy.DefaultNamingStrategy;
@@ -53,7 +54,10 @@ public class TestSnowflakeStorage extends TestSQLStorage {
 
     private static final String SNOWFLAKE_PASSWORD = Nullsafe.orDefault(System.getenv("SNOWFLAKE_PASSWORD"));
 
-    private static final String SNOWFLAKE_DATABASE = Nullsafe.orDefault(System.getenv("SNOWFLAKE_DATABASE"), "DEMO_DB");
+    private static final String SNOWFLAKE_DATABASE = Nullsafe.orDefault(System.getenv("SNOWFLAKE_DATABASE"));
+
+    // This database exists in a demo account, it is only used as the default DB in the custom name override test
+    private static final String SNOWFLAKE_DEFAULT_DATABASE = Nullsafe.orDefault(System.getenv("SNOWFLAKE_DEFAULT_DATABASE"), "SNOWFLAKE");
 
     @Override
     protected SQLDialect dialect() {
@@ -115,13 +119,14 @@ public class TestSnowflakeStorage extends TestSQLStorage {
         ds.setUrl("jdbc:snowflake://" + SNOWFLAKE_ACCOUNT + "." + SNOWFLAKE_REGION + ".snowflakecomputing.com/?TIMEZONE=UTC");
         ds.setUsername(SNOWFLAKE_USERNAME);
         ds.setPassword(SNOWFLAKE_PASSWORD);
-        ds.setDefaultCatalog("UTIL_DB");
+        ds.setDefaultCatalog(SNOWFLAKE_DEFAULT_DATABASE);
 
         final SQLDialect dialect = dialect();
 
         final String objectSchema = "obj_" + UUID.randomUUID().toString().replaceAll("-", "_");
         final SQLStrategy strategy = DefaultSQLStrategy.builder()
                 .namingStrategy(DefaultNamingStrategy.builder()
+                        .columnCasing(Casing.LOWERCASE_SNAKE)
                         .objectSchemaName(objectSchema)
                         .dialect(dialect)
                         .build())

--- a/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
+++ b/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
@@ -48,7 +48,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -261,10 +260,10 @@ public abstract class TestStorage {
 
         bulkLoad(storage, init);
 
-        final List<Sort> sort = ImmutableList.of(
+        final List<Sort> sort = schema.sort(ImmutableList.of(
                 Sort.desc(Name.of("city")),
                 Sort.asc(Name.of("zip"))
-        );
+        ));
 
         final Expression expr = Expression.parse("country == '" + country + "'");
         final Pager<Map<String, Object>> pager = storage.query(Consistency.ASYNC, schema, Immutable.map(), expr, sort, Collections.emptySet());
@@ -324,10 +323,10 @@ public abstract class TestStorage {
 
         bulkLoad(storage, init);
 
-        final List<Sort> sort = ImmutableList.of(
+        final List<Sort> sort = schema.sort(ImmutableList.of(
                 Sort.asc(Name.of("city")),
                 Sort.asc(Name.of("zip"))
-        );
+        ));
 
         final Expression expr = Expression.parse("country == '" + country + "'");
         final Pager<Map<String, Object>> pager = storage.query(Consistency.ASYNC, schema, Immutable.map(), expr, sort, Collections.emptySet());
@@ -348,8 +347,7 @@ public abstract class TestStorage {
             page.forEach(object -> results.add(Instance.getId(object)));
             token = page.getPaging();
         }
-        List<String> collect = results.stream().sorted()
-                .collect(Collectors.toList());
+
         assertEquals(100, results.size());
     }
 

--- a/basestar-storage/src/test/resources/io/basestar/storage/schema.yml
+++ b/basestar-storage/src/test/resources/io/basestar/storage/schema.yml
@@ -316,19 +316,6 @@ SqlView:
     count:
       type: integer
 
-SimpleSqlFunction:
-  type: function
-  arguments:
-    - name: x
-      type: string
-    - name: y
-      type: string
-  returns: string
-  language: sql
-  definition: |
-    begin
-      return "x" in ('a', 'b', 'c') and "y" in ('x', 'y', 'z');
-    end;
 ExternalView:
   type: view
   properties:


### PR DESCRIPTION
There are no new specific tests for this functionality here, because the existing tests for snowflake already exercise this codepath comprehensively.

This PR also contains a fix for a test failure on snowflake when nullable values are used as order fields, it is a workaround for a bug in JOOQ described here: https://groups.google.com/g/jooq-user/c/kABZWPQScSU, but it only seemed to surface in Snowflake tests which are usually disabled.
