### PR TITLE
DPT-990 Snowflake support for for-any/for-all

### DIFF
--- a/basestar-storage-sql/src/main/java/io/basestar/storage/sql/SQLDialect.java
+++ b/basestar-storage-sql/src/main/java/io/basestar/storage/sql/SQLDialect.java
@@ -3,11 +3,13 @@ package io.basestar.storage.sql;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.basestar.schema.*;
+import io.basestar.schema.expression.InferenceContext;
 import io.basestar.schema.use.*;
 import io.basestar.schema.util.Casing;
 import io.basestar.secret.Secret;
 import io.basestar.storage.sql.resolver.FieldResolver;
 import io.basestar.storage.sql.resolver.ValueResolver;
+import io.basestar.storage.sql.strategy.NamingStrategy;
 import io.basestar.storage.sql.util.DelegatingDatabaseMetaData;
 import io.basestar.util.Name;
 import io.basestar.util.*;
@@ -23,6 +25,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -841,5 +844,11 @@ public interface SQLDialect {
             }
         }
         return true;
+    }
+
+    default SQLExpressionVisitor expressionResolver(final NamingStrategy namingStrategy, final QueryableSchema schema, final Function<Name, QueryPart> columnResolver) {
+
+        final InferenceContext inferenceContext = InferenceContext.from(schema);
+        return new SQLExpressionVisitor(this, inferenceContext, columnResolver);
     }
 }

--- a/basestar-storage-sql/src/main/java/io/basestar/storage/sql/strategy/SQLStrategy.java
+++ b/basestar-storage-sql/src/main/java/io/basestar/storage/sql/strategy/SQLStrategy.java
@@ -20,10 +20,13 @@ package io.basestar.storage.sql.strategy;
  * #L%
  */
 
+import io.basestar.schema.QueryableSchema;
 import io.basestar.schema.Schema;
+import io.basestar.storage.sql.SQLExpressionVisitor;
 import io.basestar.storage.sql.util.DDLStep;
 import org.jooq.DSLContext;
 import org.jooq.Name;
+import org.jooq.QueryPart;
 import org.jooq.Table;
 import org.jooq.conf.StatementType;
 import org.slf4j.Logger;
@@ -31,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 public interface SQLStrategy {
 
@@ -60,4 +64,8 @@ public interface SQLStrategy {
 
         return dialect().describeTable(context, name);
     }
+
+    SQLExpressionVisitor expressionVisitor(QueryableSchema schema);
+
+    SQLExpressionVisitor expressionVisitor(QueryableSchema schema, Function<io.basestar.util.Name, QueryPart> columnResolver);
 }

--- a/basestar-storage-sql/src/test/java/io/basestar/storage/sql/TestH2SQLStorageNoMetadata.java
+++ b/basestar-storage-sql/src/test/java/io/basestar/storage/sql/TestH2SQLStorageNoMetadata.java
@@ -1,0 +1,39 @@
+package io.basestar.storage.sql;
+
+/*-
+ * #%L
+ * basestar-storage-sql
+ * %%
+ * Copyright (C) 2019 - 2020 Basestar.IO
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class TestH2SQLStorageNoMetadata extends TestH2SQLStorage {
+
+    @Override
+    protected boolean useMetadata() {
+
+        return false;
+    }
+
+    @Override
+    public void testSqlView() {
+
+        // This test requires metadata in the current implementation
+    }
+}

--- a/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
+++ b/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
@@ -1094,22 +1094,22 @@ public abstract class TestStorage {
         assertEquals(1, Instance.getVersion(current));
     }
 
-    private Page<Map<String, Object>> page(final Storage storage, final ObjectSchema schema, final Expression expression, final List<Sort> sort, final int count) {
+    protected Page<Map<String, Object>> page(final Storage storage, final ObjectSchema schema, final Expression expression, final List<Sort> sort, final int count) {
 
         return page(storage, schema, expression, sort, Collections.emptySet(), count);
     }
 
-    private Page<Map<String, Object>> page(final Storage storage, final ObjectSchema schema, final Expression expression, final List<Sort> sort, final Set<Name> expand, final int count) {
+    protected Page<Map<String, Object>> page(final Storage storage, final ObjectSchema schema, final Expression expression, final List<Sort> sort, final Set<Name> expand, final int count) {
 
         return storage.query(Consistency.ATOMIC, schema, Immutable.map(), expression.bind(Context.init()), sort, expand).page(count).join();
     }
 
-    private String createComplete(final Storage storage, final ObjectSchema schema, final Map<String, Object> data) {
+    protected String createComplete(final Storage storage, final ObjectSchema schema, final Map<String, Object> data) {
 
         return createComplete(storage, schema, UUID.randomUUID().toString(), data);
     }
 
-    private String createComplete(final Storage storage, final ObjectSchema schema, final String id, final Map<String, Object> data) {
+    protected String createComplete(final Storage storage, final ObjectSchema schema, final String id, final Map<String, Object> data) {
 
         final StorageTraits traits = storage.storageTraits(schema);
         final Map<String, Object> instance = instance(schema, id, 1L, data);
@@ -1127,12 +1127,12 @@ public abstract class TestStorage {
         return id;
     }
 
-    private Instance instance(final ObjectSchema schema, final String id, final long version) {
+    protected Instance instance(final ObjectSchema schema, final String id, final long version) {
 
         return instance(schema, id, version, Collections.emptyMap());
     }
 
-    private Instance instance(final ObjectSchema schema, final String id, final long version, final Map<String, Object> data) {
+    protected Instance instance(final ObjectSchema schema, final String id, final long version, final Map<String, Object> data) {
 
         final Instant now = ISO8601.now();
         final Map<String, Object> instance = new HashMap<>(data);
@@ -1145,7 +1145,7 @@ public abstract class TestStorage {
         return schema.create(instance, schema.getExpand(), false);
     }
 
-    private static void assertCause(final Class<? extends Throwable> except, final Executable exe) {
+    protected static void assertCause(final Class<? extends Throwable> except, final Executable exe) {
 
         boolean thrown = true;
         try {


### PR DESCRIPTION
Implements for-any and for-all behaviour, assuming the following:

 - the current schema is an object schema, or a sql view with a defined primary key
 - the iterator used is an array (value type) iterator rather than a map (key-value type) iterator
 - the iterator is over a simple column (collapses to a constant name)
 
The last two conditions could probably be relaxed, but want to establish if this is a viable/performant enough implementation first.

Approach used is to create a non-correlated subquery in the where clause that lateral joins the table of the current row to the flattened iterated column, and then boolean and/or aggregate the result of applying the lhs condition to each rhs value. This subquery is then implicitly joined to the current row using tuple-equality over the id columns and the expected 'true' result of the boolean aggregation.

This may be less performant than a UDF implementation in that the result of other terms in the surrounding query cannot short-circuit the inclusion of the related records in the subquery. However, this is more likely to get optimized by the query planner than an opaque UDF.